### PR TITLE
Add support for custom tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/rs/zerolog v1.32.0
 	github.com/vektah/gqlparser/v2 v2.5.11
 	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225
+	golang.org/x/mod v0.16.0
 	golang.org/x/sync v0.6.0
 )
 
@@ -17,6 +18,5 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sosodev/duration v1.2.0 // indirect
-	golang.org/x/mod v0.16.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 )


### PR DESCRIPTION
We want to pick a custom image tag to use, i.e. `dev`. Others are likely to want to pick `latest`, while someone else might need `main`. This allows any custom image tag to be set, and it will be added to the generated versions.

While this was the simplest thing, we may want to add support for multiple tags in the future.
